### PR TITLE
Added dual licensing to get around WTFPL concerns.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2014-2018 Sam Adams <adams.sam@gmail.com>
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lite-url",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "authors": [
     "Sam Adams <adams.sam@gmail.com>"
   ],
@@ -10,7 +10,7 @@
     "uri",
     "url parsing"
   ],
-  "license": "WTFPL",
+  "license": "(WTFPL OR BSD)",
   "homepage": "https://github.com/sadams/lite-url",
   "bugs": "https://github.com/sadams/lite-url/issues",
   "repository": {


### PR DESCRIPTION
My company's lawyers are doing an audit of our software dependency licenses, and they're claiming WTFPL isn't a valid license or they have some sort of problem with it.

This PR adds dual licensing, I'm hoping this can get merged in so I don't have to swap out this lib with another one.